### PR TITLE
Updated the mistake in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ A lightweight, self-hosted bookmark dashboard built with Go and vanilla JavaScri
 
 ### Using Docker Compose
 
-```services:
+```
+services:
   thinkdashboard:
     image: ghcr.io/matiasdesuu/thinkdashboard:latest
     container_name: thinkdashboard


### PR DESCRIPTION
<img width="1180" height="441" alt="Image" src="https://github.com/user-attachments/assets/b731beba-176b-46c3-ae9e-6d5d3104d321" />

There was a mistake README.md file, which did not show 'services:', which would break the build while copy and pasting the code into docker compose.yml.
