### PR TITLE
Fix getting month in current language

### DIFF
--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -729,7 +729,8 @@ class Dashboard {
             
             // Set date content
             const today = new Date();
-            const month = today.toLocaleString('default', { month: 'short' });
+            const lang = this.settings.language;
+            const month = today.toLocaleString(lang, { month: 'short' });
             const day = String(today.getDate()).padStart(2, '0');
             const year = today.getFullYear();
             dateElement.textContent = `${day}/${month}/${year}`;


### PR DESCRIPTION
I noticed that date displayed in dashboard, is not translated for selected language. Here is a small change, that should fix it.