### PR TITLE
Added skipFastPing setting

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -967,30 +967,35 @@ func (h *Handlers) PingURL(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Get skipFastPing query parameter
+	skipFastPing := r.URL.Query().Get("skipFastPing")
+
 	// Start timing
 	start := time.Now()
 
-	// Try TCP connection first (fast ping)
-	address := net.JoinHostPort(host, port)
-	conn, err := net.DialTimeout("tcp", address, 2*time.Second)
+	if skipFastPing == "" {
+		// Try TCP connection first (fast ping)
+		address := net.JoinHostPort(host, port)
+		conn, err := net.DialTimeout("tcp", address, 2*time.Second)
 
-	if err == nil {
-		conn.Close()
-		elapsed := time.Since(start).Milliseconds()
-		// Ensure minimum of 1ms for display purposes
-		if elapsed < 1 {
-			elapsed = 1
+		if err == nil {
+			conn.Close()
+			elapsed := time.Since(start).Milliseconds()
+			// Ensure minimum of 1ms for display purposes
+			if elapsed < 1 {
+				elapsed = 1
+			}
+
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"status": "online",
+				"ping":   elapsed,
+			})
+			return
 		}
-
-		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"status": "online",
-			"ping":   elapsed,
-		})
-		return
 	}
 
-	// If TCP fails, try a quick HTTP request as fallback
+	// If TCP fails (or fast ping disabled), try a quick HTTP request as fallback
 	client := &http.Client{
 		Timeout: 3 * time.Second,
 		Transport: &http.Transport{
@@ -1026,7 +1031,7 @@ func (h *Handlers) PingURL(w http.ResponseWriter, r *http.Request) {
 		elapsed = 1
 	}
 
-	if err == nil && resp != nil {
+	if err == nil && resp != nil && resp.StatusCode >= 200 && resp.StatusCode < 400 {
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"status": "online",

--- a/locales/en.json
+++ b/locales/en.json
@@ -76,6 +76,7 @@
     "showBookmarkStatus": "Show bookmark status (online/offline)",
     "showPingTimes": "Show ping times (ms)",
     "showStatusLoading": "Show status loading indicator",
+    "skipFastPing": "Skip fast ping check",
     "categoriesPageLabel": "Categories page:",
     "bookmarksPageLabel": "Bookmarks page:",
     "addPage": "Add Page",

--- a/locales/es.json
+++ b/locales/es.json
@@ -76,6 +76,7 @@
     "showBookmarkStatus": "Mostrar estado del marcador (en línea/fuera de línea)",
     "showPingTimes": "Mostrar tiempos de ping (ms)",
     "showStatusLoading": "Mostrar indicador de carga de estado",
+    "skipFastPing": "Omitir comprobación rápida de ping",
     "categoriesPageLabel": "Página de categorías:",
     "bookmarksPageLabel": "Página de marcadores:",
     "addPage": "Agregar Página",

--- a/locales/jp.json
+++ b/locales/jp.json
@@ -76,6 +76,7 @@
     "showBookmarkStatus": "ブックマークステータスを表示 (オンライン/オフライン)",
     "showPingTimes": "ピング時間を表示 (ms)",
     "showStatusLoading": "ステータス読み込みインジケーターを表示",
+    "skipFastPing": "Skip fast ping check",
     "categoriesPageLabel": "カテゴリページ:",
     "bookmarksPageLabel": "ブックマークページ:",
     "addPage": "ページを追加",

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -76,6 +76,7 @@
     "showBookmarkStatus": "Pokaż status zakładek (online/offline)",
     "showPingTimes": "Pokaż czasy ping (ms)",
     "showStatusLoading": "Pokaż wskaźnik ładowania statusu",
+    "skipFastPing": "Pomiń szybkie sprawdzanie statusu (ping)",
     "categoriesPageLabel": "Strona kategorii:",
     "bookmarksPageLabel": "Strona zakładek:",
     "addPage": "Dodaj stronę",

--- a/models.go
+++ b/models.go
@@ -52,6 +52,7 @@ type Settings struct {
 	ShowStatus                bool   `json:"showStatus"`
 	ShowPing                  bool   `json:"showPing"`
 	ShowStatusLoading         bool   `json:"showStatusLoading"`
+	SkipFastPing		      bool   `json:"skipFastPing"`
 	GlobalShortcuts           bool   `json:"globalShortcuts"`           // Use shortcuts from all pages
 	HyprMode                  bool   `json:"hyprMode"`                  // Launcher mode for PWA usage
 	AnimationsEnabled         bool   `json:"animationsEnabled"`         // Enable or disable animations globally
@@ -188,6 +189,7 @@ func (fs *FileStore) initializeDefaultFiles() {
 			ShowStatus:         false,
 			ShowPing:           false,
 			ShowStatusLoading:  true,
+			SkipFastPing: 		false,
 			GlobalShortcuts:    true,
 			HyprMode:           false,
 			AnimationsEnabled:  true, // Default to animations enabled

--- a/static/js/config.js
+++ b/static/js/config.js
@@ -36,6 +36,7 @@ class ConfigManager {
             showDate: true,
             showStatus: false,
             showPing: false,
+            skipFastPing: false,
             globalShortcuts: true,
             hyprMode: false,
             showPageNamesInTabs: false,

--- a/static/js/config/config-settings.js
+++ b/static/js/config/config-settings.js
@@ -460,6 +460,15 @@ class ConfigSettings {
             });
         }
 
+        // Skip fast ping checkbox
+        const skipFastPingCheckbox = document.getElementById('skip-fast-ping-checkbox');
+        if (skipFastPingCheckbox) {
+            skipFastPingCheckbox.checked = settings.skipFastPing;
+            skipFastPingCheckbox.addEventListener('change', (e) => {
+                settings.skipFastPing = e.target.checked;
+            });
+        }
+
         // Global shortcuts checkbox
         const globalShortcutsCheckbox = document.getElementById('global-shortcuts-checkbox');
         if (globalShortcutsCheckbox) {
@@ -517,6 +526,7 @@ class ConfigSettings {
         const showStatusCheckbox = document.getElementById('show-status-checkbox');
         const showPingCheckbox = document.getElementById('show-ping-checkbox');
         const showStatusLoadingCheckbox = document.getElementById('show-status-loading-checkbox');
+        const skipFastPingCheckbox = document.getElementById('skip-fast-ping-checkbox');
         const globalShortcutsCheckbox = document.getElementById('global-shortcuts-checkbox');
         const animationsEnabledCheckbox = document.getElementById('animations-enabled-checkbox');
         const enableCustomTitleCheckbox = document.getElementById('enable-custom-title-checkbox');
@@ -542,6 +552,7 @@ class ConfigSettings {
         if (showStatusCheckbox) settings.showStatus = showStatusCheckbox.checked;
         if (showPingCheckbox) settings.showPing = showPingCheckbox.checked;
         if (showStatusLoadingCheckbox) settings.showStatusLoading = showStatusLoadingCheckbox.checked;
+        if (skipFastPingCheckbox) settings.skipFastPing = skipFastPingCheckbox.checked;
         if (globalShortcutsCheckbox) settings.globalShortcuts = globalShortcutsCheckbox.checked;
         if (enableCustomTitleCheckbox) settings.enableCustomTitle = enableCustomTitleCheckbox.checked;
         if (customTitleInput) settings.customTitle = customTitleInput.value;

--- a/static/js/status.js
+++ b/static/js/status.js
@@ -45,7 +45,7 @@ class StatusMonitor {
             const timeoutId = setTimeout(() => controller.abort(), 3000); // 3 second timeout (reduced from 8s)
 
             // Use the server-side ping API which can handle HTTPS certificates
-            const response = await fetch(`/api/ping?url=${encodeURIComponent(bookmark.url)}`, {
+            const response = await fetch(`/api/ping?url=${encodeURIComponent(bookmark.url)}${this.settings.skipFastPing ? "&skipFastPing=1" : ""}`, {
                 method: 'GET',
                 headers: {
                     'Content-Type': 'application/json',

--- a/templates/config.html
+++ b/templates/config.html
@@ -187,8 +187,15 @@
                             <span class="checkbox-text" data-i18n="config.showStatusLoading">Show status loading indicator</span>
                         </label>
                     </div>
+                    <div class="checkbox-tree-item checkbox-tree-child">
+                        <span class="tree-symbol">└──</span>
+                        <label class="checkbox-label">
+                            <input type="checkbox" id="skip-fast-ping-checkbox">
+                            <span class="checkbox-text" data-i18n="config.skipFastPing">Skip fast ping check</span>
+                        </label>
+                    </div>
 
-                                        <h3 class="section-title" data-i18n="config.advancedSection">General</h3>
+                    <h3 class="section-title" data-i18n="config.advancedSection">General</h3>
                     <div class="checkbox-tree-item">
                         <label class="checkbox-label">
                             <input type="checkbox" id="hypr-mode-checkbox">


### PR DESCRIPTION
Hi. I would like to propose a small change in checking bookmark's status. I think making just TCP request to a port is not enough in most cases. It would be more beneficial if also status code is being checked. So I added a new setting which, when enabled, skips the fast ping check.

This is just an idea of change. Feel free to either merge this, or implement this in your way.

PS. I don't speak Spanish, so it is Google-translated. The same for Japanese, but this time I didn't even tried to translate it ;)